### PR TITLE
chore(settings): Registra la app 'api' en INSTALLED_APPS de Django

### DIFF
--- a/AgroRegistro/settings.py
+++ b/AgroRegistro/settings.py
@@ -37,6 +37,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'api',
 ]
 
 MIDDLEWARE = [


### PR DESCRIPTION
Se actualiza el archivo settings.py para incluir la app 'api' en la lista de aplicaciones instaladas.
Esto permite que Django detecte sus modelos, vistas, y archivos relacionados correctamente.